### PR TITLE
Add basic EMIS TEX importer and preview page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@
 - You need to set ALLOWED_HOSTS to the OS address for the webapp to be accessible via OS
 - For the admin/login function to workon OS you need to set the CSRF_TRUSTED_ORIGINS to the same OS address
 - The easiest way to set up the superuser is to connect to the OS PostgreSQL instance using the terminal oc method and then perform the createsuperuser in the local VS Code version of the Django webapp - you may need to change the database name in the local .env file if it doesn't match the one used in the OS version.
+
+## Importing EMIS Templates
+
+Visit `/import-tex/` to upload an EMIS PCS `.tex` file and preview its layout.

--- a/myapp/forms.py
+++ b/myapp/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class TexUploadForm(forms.Form):
+    tex_file = forms.FileField(label="TEX file")

--- a/myapp/templates/import_tex.html
+++ b/myapp/templates/import_tex.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>Import EMIS Template</h1>
+  <form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Upload</button>
+  </form>
+  {% if controls %}
+    <h2>Preview</h2>
+    <div style="position:relative; border:1px solid #ccc; width:{{ canvas.width }}px; height:{{ canvas.height }}px;">
+      {% for c in controls %}
+        <div style="position:absolute;
+                    left:{{ c.x }}px;
+                    top:{{ c.y }}px;
+                    width:{{ c.width }}px;
+                    height:{{ c.height }}px;
+                    border:1px solid #000;
+                    overflow:hidden;
+                    font-size:12px;">
+          {{ c.type }}: {{ c.name }}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/myapp/tex_parser.py
+++ b/myapp/tex_parser.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class Property:
+    name: str
+    value: str
+
+@dataclass
+class Control:
+    type: str
+    name: str
+    x: int
+    y: int
+    width: int
+    height: int
+    properties: List[Property] = field(default_factory=list)
+
+
+def parse_tex(content: str) -> List[Control]:
+    blocks = content.split("'''")
+    controls: List[Control] = []
+    template_name = None
+    for block in blocks:
+        block = block.strip()
+        if not block:
+            continue
+        first_tilde = block.find('~')
+        if first_tilde == -1:
+            continue
+        ctrl_type = block[1:first_tilde]
+        second_tilde = block.find('~', first_tilde + 1)
+        ctrl_name = block[first_tilde + 1:second_tilde]
+        if template_name is None:
+            template_name = ctrl_name
+        rest = block[second_tilde + 1:]
+        coord_end = rest.find("'#13#10")
+        coords_part = rest[:coord_end] if coord_end != -1 else rest
+        coords = [0, 0, 0, 0]
+        try:
+            coords = list(map(int, coords_part.split(',')[:4]))
+        except ValueError:
+            pass
+        properties: List[Property] = []
+        prop_parts = block.split("'Prop")[1:]
+        for p in prop_parts:
+            pclean = p.replace("'#13#10'", "").replace("'#13#10", "")
+            pclean = pclean.lstrip('~')
+            pieces = pclean.split('~')
+            if len(pieces) >= 5:
+                prop_name = pieces[2]
+                value = pieces[4]
+                properties.append(Property(prop_name, value))
+        controls.append(Control(ctrl_type, ctrl_name, *coords, properties))
+    return controls

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
     path('consultations/', views.consultation_list, name='consultation_list'),
     path('consultations/<int:consultation_id>/', views.consultation_detail, name='consultation_detail'),
     path('consultations/<int:consultation_id>/events/', views.consultation_combined_view, name='consultation_combined'),
+    path('import-tex/', views.import_tex_view, name='import_tex'),
 ]


### PR DESCRIPTION
## Summary
- parse EMIS PCS `.tex` template files into structured control objects
- add upload page that previews controls positioned from the TEX data
- document new `/import-tex/` route

## Testing
- `DB_NAME=test DB_USER=test DB_PASSWORD=test DB_HOST=localhost python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68566682ac2883279bd5ad4cd1262f48